### PR TITLE
메인 배너 이미지의 비율 수정

### DIFF
--- a/src/components/Banner/Banner.style.ts
+++ b/src/components/Banner/Banner.style.ts
@@ -1,8 +1,9 @@
-import { styled } from "@/libs";
+import { styled } from '@/libs';
 
 export const Container = styled.section`
   --indicator-width: 1060px;
   position: relative;
+
   & img {
     border-radius: 30px / 25px;
     width: 100%;
@@ -51,33 +52,30 @@ export const Container = styled.section`
     height: 100%;
   }
 
+  & .swiper-slide {
+    width: var(--indicator-width);
+    height: auto;
+
+    aspect-ratio: 212 / 75;
+  }
+
   ${({ theme }) => theme.media.desktop`
       --indicator-width: 1060px;
-      & .swiper-slide {
-        height: 375px;
-        width: 1060px !important;
-      }
   `}
+
   ${({ theme }) => theme.media.tablet`
-      
       --indicator-width: 720px;
+
       .carousel-handle {
         display: none;
-      }
-      & .swiper-slide {
-        width: 720px !important;
-        height: 200px;
       }
   `}
   
   ${({ theme }) => theme.media.mobile`
       --indicator-width: 290px;
+
       & .banner__indicator-con {
         display: none;
-      }
-      & .swiper-slide {
-        height: 180px;
-        width: 290px !important;
       }
   `}
 `;


### PR DESCRIPTION
메인 배너들의 이미지가 태블릿 / 모바일 환경에서 찌그러지는 문제를 해결했습니다

사이트의 사용자인 제가 이미지가 찌그러지는 것을 도저히 못 참겠어서 PR을 남기는 거지만,
만약 디자인 팀에서 검토 후 의도된 디자인이였거나, 다른 특이사항이 있어서 이대로 놔둔거라면 그냥 닫아주셔도 됩니다

좋은 사이트 같습니다!

![image](https://github.com/ChimPlanet/chimplanet-ui/assets/61264156/0ba5d7da-8fc3-418f-b73e-3b864a963560)


## 스크린샷

![pc](https://github.com/ChimPlanet/chimplanet-ui/assets/61264156/4265a8d2-39c7-42a0-a906-0062d89fc3ec)
![tablet](https://github.com/ChimPlanet/chimplanet-ui/assets/61264156/104c8d1d-bfb4-404a-8a43-be5eb2825ebe)
![image](https://github.com/ChimPlanet/chimplanet-ui/assets/61264156/bf67754f-82aa-4dde-b8aa-1631519311c5)
